### PR TITLE
Modified arbiter to get valid GCS access token on windows.

### DIFF
--- a/cmake/execinfo.cmake
+++ b/cmake/execinfo.cmake
@@ -1,4 +1,6 @@
 #
 # Unwind
 #
-find_package(Libexecinfo QUIET)
+if(NOT MSVC)
+    find_package(Libexecinfo )
+endif()

--- a/cmake/unwind.cmake
+++ b/cmake/unwind.cmake
@@ -1,4 +1,6 @@
 #
 # Unwind
 #
-find_package(Libunwind QUIET)
+if(NOT MSVC)
+    find_package(Libunwind QUIET)
+endif()

--- a/vendor/arbiter/CMakeLists.txt
+++ b/vendor/arbiter/CMakeLists.txt
@@ -21,7 +21,7 @@ target_compile_definitions(${PDAL_ARBITER_LIB_NAME}
         ARBITER_CURL)
 
 if (MSVC)
-    find_library(SHLWAPI Shlwapi.lib)
+    set(SHLWAPI ShLwApi)
     target_link_libraries(${PDAL_ARBITER_LIB_NAME} PRIVATE ${SHLWAPI})
     target_compile_definitions(${PDAL_ARBITER_LIB_NAME}
         PRIVATE

--- a/vendor/arbiter/arbiter.cpp
+++ b/vendor/arbiter/arbiter.cpp
@@ -4601,6 +4601,10 @@ std::string encodeAsHex(const std::string& input)
 #include <arbiter/util/types.hpp>
 #endif
 
+#ifdef WINDOWS
+#include<chrono>
+#endif // WINDOWS
+
 #ifdef ARBITER_CUSTOM_NAMESPACE
 namespace ARBITER_CUSTOM_NAMESPACE
 {
@@ -4613,6 +4617,18 @@ namespace
 {
     std::mutex mutex;
 
+#ifdef WINDOWS
+	int64_t utcToLocalOffsetSeconds() {
+        std::chrono::time_point<std::chrono::system_clock> time =
+            std::chrono::system_clock::now();
+        std::time_t now = std::chrono::system_clock::to_time_t(time);
+
+        std::lock_guard<std::mutex> lock(mutex);
+        std::tm utc(*std::gmtime(&now));
+        std::tm loc(*std::localtime(&now));
+        return (int64_t)std::difftime(std::mktime(&utc), std::mktime(&loc));
+	}
+#else
     int64_t utcOffsetSeconds(const std::time_t& now)
     {
         std::lock_guard<std::mutex> lock(mutex);
@@ -4620,6 +4636,7 @@ namespace
         std::tm loc(*std::localtime(&now));
         return (int64_t)std::difftime(std::mktime(&utc), std::mktime(&loc));
     }
+#endif // WINDOWS
 }
 
 const std::string Time::iso8601 = "%Y-%m-%dT%H:%M:%SZ";
@@ -4649,7 +4666,12 @@ Time::Time(const std::string& s, const std::string& format)
         throw ArbiterError("Failed to parse " + s + " as time: " + format);
     }
 #endif
+
+#ifdef WINDOWS
+    const int64_t utcOffset(utcToLocalOffsetSeconds());
+#else
     const int64_t utcOffset(utcOffsetSeconds(std::mktime(&tm)));
+#endif // WINDOWS
 
     if (utcOffset > std::numeric_limits<int>::max())
         throw ArbiterError("Can't convert offset time in seconds to tm type.");


### PR DESCRIPTION
- `Libexecinfo` and `Libunwind` are not for windows, Modified to ignore them on windows.
- `ShLwApi` is already in path.
- `utcOffsetSeconds` throws an null pointer exception on windows. Which causes the failure in retriving the access token from GCS. Added new method for windows named `utcToLocalOffsetSeconds` which will return the UTC to Local time difference. After this arbiter can retrieve a valid access token from 
GCS.