### PR TITLE
Streamable EPT Reader

### DIFF
--- a/io/EptReader.cpp
+++ b/io/EptReader.cpp
@@ -611,15 +611,15 @@ PointViewSet EptReader::run(PointViewPtr view)
     return views;
 }
 
-uint64_t EptReader::readLaszip(PointView& dst, const Key& key,
-                               const uint64_t nodeId) const
+uint64_t EptReader::readLaszip(PointView& dst, const Key& key, 
+        const uint64_t nodeId) const
 {
     // If the file is remote (HTTP, S3, Dropbox, etc.), getLocalHandle will
     // download the file and `localPath` will return the location of the
     // downloaded file in a temporary directory.  Otherwise it's a no-op.
     auto handle(m_ep->getLocalHandle("ept-data/" + key.toString() + ".laz"));
 
-	PointTable table;
+    PointTable table;
 
     Options options;
     options.add("filename", handle->localPath());
@@ -652,7 +652,8 @@ uint64_t EptReader::readLaszip(PointView& dst, const Key& key,
     return startId;
 }
 
-uint64_t EptReader::readBinary(PointView& dst, const Key& key, const uint64_t nodeId) const
+uint64_t EptReader::readBinary(PointView& dst, const Key& key, 
+        const uint64_t nodeId) const
 {
     auto data(m_ep->getBinary("ept-data/" + key.toString() + ".bin"));
     ShallowPointTable table(*m_remoteLayout, data.data(), data.size());

--- a/io/EptReader.cpp
+++ b/io/EptReader.cpp
@@ -818,17 +818,17 @@ void EptReader::fillPoint(PointRef& point)
 bool EptReader::processOne(PointRef& point)
 {
     if (m_nodeId > m_overlaps.size() && m_currentIndex==-1)
-		//We're done with all overlaps, Its time to finish reading.
+        //We're done with all overlaps, Its time to finish reading.
         return false;
 
     if (m_currentIndex == -1)
-		//Either this is a first overlap or we've streamed all points from current overlap. So its time to load new overlap.
+        //Either this is a first overlap or we've streamed all points from current overlap. So its time to load new overlap.
         loadNextOverlap();
 
     fillPoint(point);
 
     if (m_currentIndex >= m_bufferPointView->size())
-		// We're done with all points from current overlap.
+        // We're done with all points from current overlap.
         m_currentIndex = -1;
 
     return true;

--- a/io/EptReader.cpp
+++ b/io/EptReader.cpp
@@ -436,10 +436,10 @@ void EptReader::addDimensions(PointLayoutPtr layout)
         throwError(e.what());
     }
 
-	// Backup the layout for streamable pipeline.
-	// Will be used to restore m_bufferPointTable layout after flushing points from previous tile.
-	if (pipelineStreamable())
-		m_bufferLayout = layout;
+    // Backup the layout for streamable pipeline.
+    // Will be used to restore m_bufferPointTable layout after flushing points from previous tile.
+    if (pipelineStreamable())
+    	m_bufferLayout = layout;
 }
 
 void EptReader::ready(PointTableRef table)
@@ -783,18 +783,18 @@ void EptReader::loadNextOverlap()
 
     uint64_t startId(0);
 
-	// Reset PointTable to make sure all points from previous tile are flushed.
+    // Reset PointTable to make sure all points from previous tile are flushed.
     m_bufferPointTable.reset(new PointTable());
 
-	// We did reset PointTable,
-	// So it will not have the dimensions registered to it.
-	// Register/Restore Dimensions for PointTable layout.
+    // We did reset PointTable,
+    // So it will not have the dimensions registered to it.
+    // Register/Restore Dimensions for PointTable layout.
     PointLayoutPtr layout = m_bufferPointTable->layout();
     for (auto id : m_bufferLayout->dims())
         layout->registerOrAssignDim(m_bufferLayout->dimName(id),
                                     m_bufferLayout->dimType(id));
 
-	// Reset PointView to have new point table.
+    // Reset PointView to have new point table.
     m_bufferPointView.reset(new PointView(*m_bufferPointTable));
 
     if (m_info->dataType() == EptInfo::DataType::Laszip)

--- a/io/EptReader.cpp
+++ b/io/EptReader.cpp
@@ -36,6 +36,7 @@
 
 #include <limits>
 
+#include "private/EptSupport.hpp"
 
 #include "LasReader.hpp"
 

--- a/io/EptReader.cpp
+++ b/io/EptReader.cpp
@@ -611,7 +611,7 @@ PointViewSet EptReader::run(PointViewPtr view)
     return views;
 }
 
-uint64_t EptReader::readLaszip(PointView& dst, const Key& key, 
+uint64_t EptReader::readLaszip(PointView& dst, const Key& key,
         const uint64_t nodeId) const
 {
     // If the file is remote (HTTP, S3, Dropbox, etc.), getLocalHandle will
@@ -652,7 +652,7 @@ uint64_t EptReader::readLaszip(PointView& dst, const Key& key,
     return startId;
 }
 
-uint64_t EptReader::readBinary(PointView& dst, const Key& key, 
+uint64_t EptReader::readBinary(PointView& dst, const Key& key,
         const uint64_t nodeId) const
 {
     auto data(m_ep->getBinary("ept-data/" + key.toString() + ".bin"));

--- a/io/EptReader.cpp
+++ b/io/EptReader.cpp
@@ -787,15 +787,14 @@ void EptReader::loadNextOverlap()
         << key.toString() << std::endl;
 
     uint64_t startId(0);
+	m_pointTable.reset(new PointTable());
 	if (m_info->dataType() == EptInfo::DataType::Laszip)
     {
-		m_pointTable.reset(new PointTable());
 		m_pointView.reset(new PointView(*m_pointTable));
 		startId=readLaszip(*m_pointView, key, m_nodeId, m_pointTable);
     }
     else
     {
-        m_pointTable.reset(new PointTable());
         std::unique_lock<std::mutex> lock(m_mutex);
         prepare(*m_pointTable);
         lock.unlock();

--- a/io/EptReader.cpp
+++ b/io/EptReader.cpp
@@ -434,6 +434,7 @@ void EptReader::addDimensions(PointLayoutPtr layout)
     {
         throwError(e.what());
     }
+    m_bufferLayout = layout;
 }
 
 void EptReader::ready(PointTableRef table)
@@ -781,10 +782,10 @@ void EptReader::loadNextOverlap()
     uint64_t startId(0);
     m_bufferPointTable.reset(new PointTable());
     PointLayoutPtr layout = m_bufferPointTable->layout();
-    for (auto id : m_remoteLayout->dims())
+    for (auto id : m_bufferLayout->dims())
     {
-        layout->registerOrAssignDim(m_remoteLayout->dimName(id),
-                                    m_remoteLayout->dimType(id));
+        layout->registerOrAssignDim(m_bufferLayout->dimName(id),
+                                    m_bufferLayout->dimType(id));
     }
 
     m_bufferPointView.reset(new PointView(*m_bufferPointTable));

--- a/io/EptReader.cpp
+++ b/io/EptReader.cpp
@@ -587,9 +587,17 @@ PointViewSet EptReader::run(PointViewPtr view)
             uint64_t startId(0);
 
             if (m_info->dataType() == EptInfo::DataType::Laszip)
-                startId = readLaszip(*view, key, nodeId);
+            {
+				std::unique_ptr<PointTable> table(nullptr);
+                startId = readLaszip(*view, key, nodeId,table);
+                table.reset(nullptr);
+			}
             else
-                startId = readBinary(*view, key, nodeId);
+            {
+                std::unique_ptr<ShallowPointTable> table(nullptr);
+                startId = readBinary(*view, key, nodeId,table);
+                table.reset(nullptr);
+			}
 
             // Read addon information after the native data, we'll possibly
             // overwrite attributes.

--- a/io/EptReader.cpp
+++ b/io/EptReader.cpp
@@ -785,11 +785,11 @@ void EptReader::loadNextOverlap()
     {
         layout->registerOrAssignDim(m_remoteLayout->dimName(id),
                                     m_remoteLayout->dimType(id));
-	}
+    }
 
-	m_bufferPointView.reset(new PointView(*m_bufferPointTable));
+    m_bufferPointView.reset(new PointView(*m_bufferPointTable));
 
-	if (m_info->dataType() == EptInfo::DataType::Laszip)
+    if (m_info->dataType() == EptInfo::DataType::Laszip)
         startId = readLaszip(*m_bufferPointView, key, m_nodeId);
     else
         startId = readBinary(*m_bufferPointView, key, m_nodeId);
@@ -809,8 +809,9 @@ void EptReader::fillPoint(PointRef& point)
 {
     DimTypeList dims = m_bufferPointView->dimTypes();
     char* buffer = new char[m_bufferPointView->pointSize()];
-    m_bufferPointView->getPackedPoint(dims, m_currentIndex++, buffer);
-	point.setPackedData(dims, buffer);
+    m_bufferPointView->getPackedPoint(dims, m_currentIndex, buffer);
+    point.setPackedData(dims, buffer);
+    m_currentIndex++;
     delete[] buffer;
 }
 

--- a/io/EptReader.hpp
+++ b/io/EptReader.hpp
@@ -105,7 +105,7 @@ private:
     static Dimension::Type getRemoteTypeTest(const NL::json& dimInfo);
     static Dimension::Type getCoercedTypeTest(const NL::json& dimInfo);
 
-	//For streamable pipeline.
+    //For streamable pipeline.
     virtual bool processOne(PointRef& point) override;
     void loadNextOverlap();
     void fillPoint(PointRef& point);
@@ -138,7 +138,7 @@ private:
     Dimension::Id m_nodeIdDim = Dimension::Id::Unknown;
     Dimension::Id m_pointIdDim = Dimension::Id::Unknown;
 
-	// For streamable pipeline.
+    // For streamable pipeline.
     uint64_t m_nodeId = 1;
     std::unique_ptr<PointTable> m_bufferPointTable;
     PointViewPtr m_bufferPointView;

--- a/io/EptReader.hpp
+++ b/io/EptReader.hpp
@@ -74,14 +74,6 @@ public:
     std::string getName() const override;
 
 private:
-    uint64_t m_nodeId = 1;
-    std::unique_ptr<PointTable> m_pointTable;
-    PointViewPtr m_pointView;
-    int m_currentIndex = -1;
-    virtual bool processOne(PointRef& point) override;
-    void loadNextOverlap();
-    void fillPoint(PointRef& point);
-
     virtual void addArgs(ProgramArgs& args) override;
     virtual void initialize() override;
     virtual QuickInfo inspect() override;
@@ -113,6 +105,11 @@ private:
     static Dimension::Type getRemoteTypeTest(const NL::json& dimInfo);
     static Dimension::Type getCoercedTypeTest(const NL::json& dimInfo);
 
+	//For streamable pipeline.
+    virtual bool processOne(PointRef& point) override;
+    void loadNextOverlap();
+    void fillPoint(PointRef& point);
+
     std::string m_root;
 
     std::unique_ptr<arbiter::Arbiter> m_arbiter;
@@ -140,6 +137,12 @@ private:
 
     Dimension::Id m_nodeIdDim = Dimension::Id::Unknown;
     Dimension::Id m_pointIdDim = Dimension::Id::Unknown;
+
+	// For streamable pipeline.
+    uint64_t m_nodeId = 1;
+    std::unique_ptr<PointTable> m_bufferPointTable;
+    PointViewPtr m_bufferPointView;
+    int m_currentIndex = -1;
 };
 
 } // namespace pdal

--- a/io/EptReader.hpp
+++ b/io/EptReader.hpp
@@ -142,6 +142,7 @@ private:
     uint64_t m_nodeId = 1;
     std::unique_ptr<PointTable> m_bufferPointTable;
     PointViewPtr m_bufferPointView;
+    PointLayoutPtr m_bufferLayout;
     int m_currentIndex = -1;
 };
 

--- a/io/EptReader.hpp
+++ b/io/EptReader.hpp
@@ -75,14 +75,11 @@ public:
 
 private:
     uint64_t m_nodeId = 1;
-    std::vector<Key> m_keys;
     std::unique_ptr<PointTable> m_pointTable;
-    std::unique_ptr<ShallowPointTable> m_shlwPointTable;
     PointViewPtr m_pointView;
     int m_currentIndex = -1;
     virtual bool processOne(PointRef& point) override;
     void loadNextOverlap();
-    void saveOverlapKeys();
     void fillPoint(PointRef& point);
 
     virtual void addArgs(ProgramArgs& args) override;
@@ -104,10 +101,8 @@ private:
     void overlaps(const arbiter::Endpoint& ep, std::map<Key, uint64_t>& target,
             const NL::json& current, const Key& key);
 
-    uint64_t readLaszip(PointView& view, const Key& key, uint64_t nodeId,
-                        std::unique_ptr<PointTable>& pointTable) const;
-    uint64_t
-    readBinary(PointView& view, const Key& key, uint64_t nodeId) const;
+    uint64_t readLaszip(PointView& view, const Key& key, uint64_t nodeId) const;
+    uint64_t readBinary(PointView& view, const Key& key, uint64_t nodeId) const;
     void process(PointView& view, PointRef& pr, uint64_t nodeId,
             uint64_t pointId) const;
 

--- a/io/EptReader.hpp
+++ b/io/EptReader.hpp
@@ -105,11 +105,10 @@ private:
             const NL::json& current, const Key& key);
 
     uint64_t readLaszip(PointView& view, const Key& key, uint64_t nodeId,
-                        std::unique_ptr<PointTable>& pointTable =
-                            (std::unique_ptr<PointTable>) nullptr) const;
+                        std::unique_ptr<PointTable>& pointTable) const;
     uint64_t
     readBinary(PointView& view, const Key& key, uint64_t nodeId,
-               std::unique_ptr<ShallowPointTable>& shlwPointTable=(std::unique_ptr<ShallowPointTable>) nullptr) const;
+               std::unique_ptr<ShallowPointTable>& shlwPointTable) const;
     void process(PointView& view, PointRef& pr, uint64_t nodeId,
             uint64_t pointId) const;
 

--- a/io/EptReader.hpp
+++ b/io/EptReader.hpp
@@ -107,8 +107,7 @@ private:
     uint64_t readLaszip(PointView& view, const Key& key, uint64_t nodeId,
                         std::unique_ptr<PointTable>& pointTable) const;
     uint64_t
-    readBinary(PointView& view, const Key& key, uint64_t nodeId,
-               std::unique_ptr<ShallowPointTable>& shlwPointTable) const;
+    readBinary(PointView& view, const Key& key, uint64_t nodeId) const;
     void process(PointView& view, PointRef& pr, uint64_t nodeId,
             uint64_t pointId) const;
 

--- a/io/EptReader.hpp
+++ b/io/EptReader.hpp
@@ -46,8 +46,6 @@
 
 #include <nlohmann/json.hpp>
 
-#include "private/EptSupport.hpp"
-
 namespace pdal
 {
 
@@ -143,7 +141,7 @@ private:
     std::unique_ptr<PointTable> m_bufferPointTable;
     PointViewPtr m_bufferPointView;
     PointLayoutPtr m_bufferLayout;
-    int m_currentIndex = -1;
+    point_count_t m_currentIndex = -1;
 };
 
 } // namespace pdal


### PR DESCRIPTION
In this PR I tried to make EPT Reader streamable. 
This PR is supposed to be submitted to PDAL directly. But I thought, first get it reviewed from our experts. 

**Test pipeline :**
```
{
   "pipeline": [
       {
           "type": "readers.ept",
           "filename": "gs://helix-dev-integration-test-data/pcp/1554304352"
       },
       {
           "type": "writers.las",
           "filename": "D:/ept-to-laz.laz"
       }
   ]
}
```
This works with both Binary as well as laszip ept pointcloud.