### PR TITLE
Added multiassign filter

### DIFF
--- a/doc/stages/filters.multiassign.rst
+++ b/doc/stages/filters.multiassign.rst
@@ -22,27 +22,27 @@ green where classification is 4 and blue where classification is >=5.
   [
       "autzen-dd.las",
       {
-        "type":"filters.multiassign",
-        "args":{
-			"assignments":[
-				{
-					"assign":"Red[:]=255,Green[:]=255,Blue[:]=255",
-					"condition":"Classification[:2]"
-				},
-				{
-					"assign":"Red[:]=255,Green[:]=0,Blue[:]=0",
-					"condition":"Classification[3:3]"
-				},
-				{
-					"assign":"Red[:]=0,Green[:]=255,Blue[:]=0",
-					"condition":"Classification[4:4]"
-				},
-				{
-					"assign":"Red[:]=0,Green[:]=0,Blue[:]=255",
-					"condition":"Classification[5:]"
-				}
-			]
-		}
+          "type":"filters.multiassign",
+          "args":{
+              "assignments":[
+		    {
+		        "assign":"Red[:]=255,Green[:]=255,Blue[:]=255",
+		        "condition":"Classification[:2]"
+		    },
+		    {
+		        "assign":"Red[:]=255,Green[:]=0,Blue[:]=0",
+		        "condition":"Classification[3:3]"
+		    },
+		    {
+		        "assign":"Red[:]=0,Green[:]=255,Blue[:]=0",
+		        "condition":"Classification[4:4]"
+		    },
+		    {
+		        "assign":"Red[:]=0,Green[:]=0,Blue[:]=255",
+		        "condition":"Classification[5:]"
+		    }
+	    ]
+          }
       },
       {
           "filename":"attributed.las",

--- a/doc/stages/filters.multiassign.rst
+++ b/doc/stages/filters.multiassign.rst
@@ -23,7 +23,7 @@ green where classification is 4 and blue where classification is >=5.
       "autzen-dd.las",
       {
         "type":"filters.multiassign",
-		"args":{
+        "args":{
 			"assignments":[
 				{
 					"assign":"Red[:]=255,Green[:]=255,Blue[:]=255",

--- a/doc/stages/filters.multiassign.rst
+++ b/doc/stages/filters.multiassign.rst
@@ -1,0 +1,67 @@
+.. _filters.multiassign:
+
+filters.multiassign
+===================
+
+The multiassign filter allows you set the values to dimensions for all points
+to a provided value that pass a range filter. This is a upgraded version of :ref:`filters.assign`
+to allow passing array of assignments with optional condition to every assignment.
+
+.. embed::
+
+.. streamable::
+
+Example 1
+---------
+
+This pipeline resets the ``Colors`` of all points to white where classification is >=2, red where classification is 3,
+green where classification is 4 and blue where classification is >=5.
+
+.. code-block:: json
+
+  [
+      "autzen-dd.las",
+      {
+        "type":"filters.multiassign",
+		"args":{
+			"assignments":[
+				{
+					"assign":"Red[:]=255,Green[:]=255,Blue[:]=255",
+					"condition":"Classification[:2]"
+				},
+				{
+					"assign":"Red[:]=255,Green[:]=0,Blue[:]=0",
+					"condition":"Classification[3:3]"
+				},
+				{
+					"assign":"Red[:]=0,Green[:]=255,Blue[:]=0",
+					"condition":"Classification[4:4]"
+				},
+				{
+					"assign":"Red[:]=0,Green[:]=0,Blue[:]=255",
+					"condition":"Classification[5:]"
+				}
+			]
+		}
+      },
+      {
+          "filename":"attributed.las",
+          "scale_x":0.0000001,
+          "scale_y":0.0000001
+      }
+  ]
+
+Options
+-------
+
+args
+  Contains arguments for assignment.
+  
+  assignment
+	A comma separated list of assignmet and condition pairs. Each pair for assignment is executed sequentially.
+
+	assign
+		A comma separated list of :ref:`range <ranges>` followed by an assignment of a value (see example).
+	
+	condition
+		A :ref:`ranges <ranges>` that a point's values must pass in order for the assignment to be performed. [Default: none]

--- a/filters/AssignFilter.cpp
+++ b/filters/AssignFilter.cpp
@@ -37,7 +37,6 @@
 #include <pdal/StageFactory.hpp>
 #include <pdal/util/ProgramArgs.hpp>
 
-#include "private/DimRange.hpp"
 
 namespace pdal
 {
@@ -50,18 +49,6 @@ static StaticPluginInfo const s_info
 };
 
 CREATE_STATIC_STAGE(AssignFilter, s_info)
-
-struct AssignRange : public DimRange
-{
-    void parse(const std::string& r);
-    double m_value;
-};
-
-struct AssignArgs
-{
-    std::vector<AssignRange> m_assignments;
-    DimRange m_condition;
-};
 
 void AssignRange::parse(const std::string& r)
 {

--- a/filters/AssignFilter.hpp
+++ b/filters/AssignFilter.hpp
@@ -36,11 +36,21 @@
 
 #include <pdal/Filter.hpp>
 #include <pdal/Streamable.hpp>
+#include "private/DimRange.hpp"
 
 namespace pdal
 {
+struct AssignRange : public DimRange
+{
+    void parse(const std::string& r);
+    double m_value;
+};
 
-struct AssignArgs;
+struct AssignArgs
+{
+    std::vector<AssignRange> m_assignments;
+    DimRange m_condition;
+};
 
 class PDAL_DLL AssignFilter : public Filter, public Streamable
 {

--- a/filters/MultiAssignFilter.cpp
+++ b/filters/MultiAssignFilter.cpp
@@ -1,0 +1,124 @@
+/******************************************************************************
+ * Copyright (c) 2019, Helix Re Inc. <pravin@helix.re>
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of Helix Re, Inc. nor the
+ *       names of its contributors may be used to endorse or promote
+ *       products derived from this software without specific prior
+ *       written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ ****************************************************************************/
+
+#include "MultiAssignFilter.hpp"
+
+#include <pdal/StageFactory.hpp>
+#include <pdal/util/ProgramArgs.hpp>
+#include "boost/algorithm/string/split.hpp"
+#include "boost/algorithm/string/classification.hpp"
+
+namespace pdal
+{
+
+static StaticPluginInfo const s_info
+{
+    "filters.multiassign",
+    "Assign values for a dimension range to a specified value.",
+    "http://pdal.io/stages/filters.multiassign.html"};
+
+
+CREATE_STATIC_STAGE(MultiAssignFilter, s_info)
+
+void MultiAssignFilter::addArgs(ProgramArgs& args)
+{
+    args.add("args", "Assignment JSON", m_json).setPositional();
+}
+
+void MultiAssignFilter::prepared(PointTableRef table)
+{
+    PointLayoutPtr layout(table.layout());
+    auto assigns = m_json.at("assignments");
+    for (auto a : assigns)
+    {
+        std::vector<std::string> res;
+        std::string assign = a.at("assign");
+        pdalboost::split(res, assign, pdalboost::is_any_of(","));
+        AssignArgs assignArgs;
+        for (auto s : res)
+        {
+            AssignRange assn;
+            assn.parse(s);
+            assn.m_id = layout->findDim(assn.m_name);
+            if (assn.m_id == Dimension::Id::Unknown)
+                throwError("Invalid dimension name in 'assignment' option: '" +
+                           assn.m_name + "'.");
+            assignArgs.m_assignments.push_back(assn);
+        }
+        if (a.contains("condition"))
+        {
+            std::string condition = a.at("condition");
+            DimRange range;
+            range.parse(condition);
+
+            range.m_id = layout->findDim(range.m_name);
+            if (range.m_id == Dimension::Id::Unknown)
+                throwError("Invalid dimension name in 'condition' option: '" +
+                           range.m_name + "'.");
+            assignArgs.m_condition = range;
+        }
+        m_assignments.push_back(assignArgs);
+    }
+
+    return;
+}
+
+bool MultiAssignFilter::processOne(PointRef& point)
+{
+    for (auto& a : m_assignments)
+    {
+        if (a.m_condition.m_id != Dimension::Id::Unknown)
+        {
+            double condVal = point.getFieldAs<double>(a.m_condition.m_id);
+            if (!a.m_condition.valuePasses(condVal))
+                continue;
+        }
+        for (auto& r : a.m_assignments)
+            if (r.valuePasses(point.getFieldAs<double>(r.m_id)))
+                point.setField(r.m_id, r.m_value);
+    }
+    return true;
+}
+
+void MultiAssignFilter::filter(PointView& view)
+{
+    PointRef point(view, 0);
+    for (PointId id = 0; id < view.size(); ++id)
+    {
+        point.setPointId(id);
+        processOne(point);
+    }
+}
+
+} // namespace pdal

--- a/filters/MultiAssignFilter.cpp
+++ b/filters/MultiAssignFilter.cpp
@@ -45,7 +45,7 @@ namespace pdal
 static StaticPluginInfo const s_info
 {
     "filters.multiassign",
-    "Assign values for a dimension range to a specified value.",
+    "Assign values for dimensions range. Supports multiple assignments with optional condition to every assignment",
     "http://pdal.io/stages/filters.multiassign.html"};
 
 

--- a/filters/MultiAssignFilter.hpp
+++ b/filters/MultiAssignFilter.hpp
@@ -1,0 +1,66 @@
+/******************************************************************************
+ * Copyright (c) 2019, Helix Re Inc. <pravin@helix.re>
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of Helix Re, Inc. nor the
+ *       names of its contributors may be used to endorse or promote
+ *       products derived from this software without specific prior
+ *       written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ ****************************************************************************/
+
+#pragma once
+#include <nlohmann/json.hpp>
+#include "AssignFilter.hpp"
+
+namespace pdal
+{
+struct AssignArgs;
+
+class PDAL_DLL MultiAssignFilter : public Filter, public Streamable
+{
+public:
+    MultiAssignFilter() {};
+
+    std::string getName() const
+    {
+        return "filters.multiassign";
+    }
+
+private:
+    virtual void addArgs(ProgramArgs& args);
+    virtual void prepared(PointTableRef table);
+    virtual bool processOne(PointRef& point);
+    virtual void filter(PointView& view);
+
+    MultiAssignFilter& operator=(const MultiAssignFilter&) = delete;
+    MultiAssignFilter(const MultiAssignFilter&) = delete;
+
+    nlohmann::json m_json;
+    std::vector<AssignArgs> m_assignments;
+};
+
+} // namespace pdal

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -351,7 +351,7 @@ if(PDAL_HAVE_LIBXML2)
         INCLUDES
             ${LIBXML2_INCLUDE_DIR}
     )
-	PDAL_ADD_TEST(pdal_filters_multiassign_test
+    PDAL_ADD_TEST(pdal_filters_multiassign_test
         FILES
             filters/MultiAssignFilterTest.cpp
         INCLUDES

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -351,4 +351,10 @@ if(PDAL_HAVE_LIBXML2)
         INCLUDES
             ${LIBXML2_INCLUDE_DIR}
     )
+	PDAL_ADD_TEST(pdal_filters_multiassign_test
+        FILES
+            filters/MultiAssignFilterTest.cpp
+        INCLUDES
+            ${NLOHMANN_INCLUDE_DIR})
+ 
 endif()

--- a/test/unit/filters/MultiAssignFilterTest.cpp
+++ b/test/unit/filters/MultiAssignFilterTest.cpp
@@ -1,0 +1,220 @@
+/******************************************************************************
+ * Copyright (c) 2019, Helix Re Inc. <pravin@helix.re>
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of Helix Re, Inc. nor the
+ *       names of its contributors may be used to endorse or promote
+ *       products derived from this software without specific prior
+ *       written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ ****************************************************************************/
+
+#include <pdal/pdal_test_main.hpp>
+
+#include <pdal/StageFactory.hpp>
+#include <pdal/util/FileUtils.hpp>
+#include "nlohmann/json.hpp"
+
+#include "Support.hpp"
+
+using namespace pdal;
+
+TEST(MultiAssignFilterTest, test_value)
+{
+    Options ro;
+    ro.add("filename", Support::datapath("autzen/autzen-dd.las"));
+
+    StageFactory factory;
+    Stage& r = *(factory.createStage("readers.las"));
+    r.setOptions(ro);
+
+    Options fo;
+    NL::json json =
+        "{\"assignments\" : [{\"assign\" : \"Red[:]=255,Green[:]=255,Blue[:]=255\"}]}"_json;
+    fo.add("args", json);
+
+    Stage& f = *(factory.createStage("filters.multiassign"));
+    f.setInput(r);
+    f.setOptions(fo);
+
+    std::string tempfile(Support::temppath("out.las"));
+
+    Options wo;
+    wo.add("filename", tempfile);
+    Stage& w = *(factory.createStage("writers.las"));
+    w.setInput(f);
+    w.setOptions(wo);
+
+    FileUtils::deleteFile(tempfile);
+    PointTable t1;
+    w.prepare(t1);
+    w.execute(t1);
+
+    Options testOptions;
+    testOptions.add("filename", tempfile);
+
+    Stage& test = *(factory.createStage("readers.las"));
+    test.setOptions(testOptions);
+
+    PointTable t2;
+    test.prepare(t2);
+    PointViewSet s = test.execute(t2);
+    PointViewPtr v = *s.begin();
+    for (PointId i = 0; i < v->size(); ++i)
+    {
+        EXPECT_EQ(v->getFieldAs<int>(Dimension::Id::Red, i), 255);
+        EXPECT_EQ(v->getFieldAs<int>(Dimension::Id::Green, i), 255);
+        EXPECT_EQ(v->getFieldAs<int>(Dimension::Id::Blue, i), 255);
+    }
+}
+TEST(MultiAssignFilterTest, test_dim_ranges)
+{
+    StageFactory factory;
+
+    Stage& r = *factory.createStage("readers.las");
+    Stage& f = *factory.createStage("filters.multiassign");
+
+    // utm17.las contains 5 points with intensity of 280, 3 of 260 and 2 of 240
+    Options ro;
+    ro.add("filename", Support::datapath("las/utm17.las"));
+    r.setOptions(ro);
+
+    Options fo;
+    NL::json json =
+        "{\"assignments\" : [{\"assign\" : \"Intensity[:250]=4,Intensity[245:270 ]=6,Intensity[272:] = 8\"}]}"_json;
+    fo.add("args", json);
+
+    f.setInput(r);
+    f.setOptions(fo);
+
+    PointTable t;
+    f.prepare(t);
+    PointViewSet s = f.execute(t);
+    PointViewPtr v = *s.begin();
+
+    int i4 = 0;
+    int i6 = 0;
+    int i8 = 0;
+    for (PointId i = 0; i < v->size(); ++i)
+    {
+        int ii = v->getFieldAs<int>(Dimension::Id::Intensity, i);
+        if (ii == 4)
+            i4++;
+        else if (ii == 6)
+            i6++;
+        else if (ii == 8)
+            i8++;
+    }
+    EXPECT_EQ(i4, 2);
+    EXPECT_EQ(i6, 3);
+    EXPECT_EQ(i8, 5);
+}
+
+TEST(MultiAssignFilterTest, test_condition)
+{
+    StageFactory factory;
+
+    Stage& r = *factory.createStage("readers.las");
+    Stage& f = *factory.createStage("filters.multiassign");
+
+    // utm17.las contains 5 points with intensity of 280, 3 of 260 and 2 of 240
+    Options ro;
+    ro.add("filename", Support::datapath("las/utm17.las"));
+    r.setOptions(ro);
+
+    Options fo;
+    NL::json json =
+        "{\"assignments\" : [{\"assign\" : \"PointSourceId[:]=6\",\"condition\":\"Intensity[260:260]\"}]}"_json;
+    fo.add("args", json);
+
+    f.setInput(r);
+    f.setOptions(fo);
+
+    PointTable t;
+    f.prepare(t);
+    PointViewSet s = f.execute(t);
+    PointViewPtr v = *s.begin();
+
+    int ielse = 0;
+    int i6 = 0;
+    for (PointId i = 0; i < v->size(); ++i)
+    {
+        int ii = v->getFieldAs<int>(Dimension::Id::PointSourceId, i);
+        if (ii == 6)
+            i6++;
+        else
+            ielse++;
+    }
+    EXPECT_EQ(i6, 3);
+    EXPECT_EQ(v->size(), 10u);
+    EXPECT_EQ(ielse, 7);
+}
+
+TEST(MultiAssignFilterTest, test_multiple_assignments)
+{
+    StageFactory factory;
+
+    Stage& r = *factory.createStage("readers.las");
+    Stage& f = *factory.createStage("filters.multiassign");
+
+    // utm17.las contains 5 points with intensity of 280, 3 of 260 and 2 of 240
+    Options ro;
+    ro.add("filename", Support::datapath("las/utm17.las"));
+    r.setOptions(ro);
+
+    Options fo;
+    NL::json json =
+        "{\"assignments\" : [{\"assign\" : \"PointSourceId[:]=6\",\"condition\":\"Intensity[260:260]\"},{\"assign\" : \"PointSourceId[:]=8\",\"condition\":\"Intensity[261:]\"},{\"assign\" : \"PointSourceId[:]=4\",\"condition\":\"Intensity[240:259]\"}]}"_json;
+    fo.add("args", json);
+
+    f.setInput(r);
+    f.setOptions(fo);
+
+    PointTable t;
+    f.prepare(t);
+    PointViewSet s = f.execute(t);
+    PointViewPtr v = *s.begin();
+
+    int ielse = 0;
+    int i6 = 0, i8=0, i4=0;
+    for (PointId i = 0; i < v->size(); ++i)
+    {
+        int ii = v->getFieldAs<int>(Dimension::Id::PointSourceId, i);
+        if (ii == 6)
+            i6++;
+        else if (ii == 8)
+            i8++;
+        else if (ii == 4)
+            i4++;
+        else
+            ielse++;
+    }
+    EXPECT_EQ(i6, 3);
+    EXPECT_EQ(i8, 5);
+    EXPECT_EQ(i4, 2);
+    EXPECT_EQ(v->size(), 10u);
+    EXPECT_EQ(ielse, 0);
+}


### PR DESCRIPTION
In this PR:
Added an upgraded version of assign filter, which can handle multiple assignments with condition associated with each assignment.
It can be used like:
```
{
     "type":"filters.multiassign",
     "args":{
	"assignments":[
		{
			"assign":"Red[:]=255,Green[:]=255,Blue[:]=255",
			"condition":"Classification[:1]"
		},
		{
			"assign":"Red[:]=255,Green[:]=0,Blue[:]=0",
			"condition":"Classification[2:3]"
		},
		{
			"assign":"Red[:]=0,Green[:]=255,Blue[:]=0",
			"condition":"Classification[4:4]"
		},
		{
			"assign":"Red[:]=0,Green[:]=0,Blue[:]=255",
			"condition":"Classification[5:]"
		}
	]
    }
}  
```
Above stage will set the color to White for classification <=1, Red for classification >=2 and <=3, Green for classification=4, Blue for classification >= 5.
`assign` is compulsary and can be comma separated list of `PDAL::DimRange=Value`
`condition` is optional and can be any `PDAL::DimRange`. If condition is not provided, assign will be applied on all points.
