### PR TITLE
Added extra dimensions support to E57 plugins.

### DIFF
--- a/plugins/e57/io/E57Reader.cpp
+++ b/plugins/e57/io/E57Reader.cpp
@@ -74,7 +74,8 @@ void E57Reader::addDimensions(PointLayoutPtr layout)
         }
     }
 
-    m_extraDims = std::make_unique<e57plugin::ExtraDims>(e57plugin::parse(m_extraDimsSpec));
+    m_extraDims = std::make_unique<e57plugin::ExtraDims>();
+    m_extraDims->parse(m_extraDimsSpec);
     auto i = m_extraDims->begin();
     while (i != m_extraDims->end())
     {

--- a/plugins/e57/io/E57Reader.cpp
+++ b/plugins/e57/io/E57Reader.cpp
@@ -74,7 +74,7 @@ void E57Reader::addDimensions(PointLayoutPtr layout)
         }
     }
 
-    m_extraDims = std::make_unique<e57plugin::ExtraDims>();
+    m_extraDims.reset(new e57plugin::ExtraDims());
     m_extraDims->parse(m_extraDimsSpec);
     auto i = m_extraDims->begin();
     while (i != m_extraDims->end())

--- a/plugins/e57/io/E57Reader.cpp
+++ b/plugins/e57/io/E57Reader.cpp
@@ -71,31 +71,31 @@ void E57Reader::addDimensions(PointLayoutPtr layout)
             m_doubleBuffers[dimension] =
                 std::vector<double>(m_defaultChunkSize, 0);
             layout->registerDim(e57plugin::e57ToPdal(dimension));
-		}
+        }
     }
 
     m_extraDims = std::make_unique<e57plugin::ExtraDims>(e57plugin::parse(m_extraDimsSpec));
     auto i = m_extraDims->begin();
     while (i != m_extraDims->end())
     {
-		// Remove extra dims which are already in layout.
+        // Remove extra dims which are already in layout.
         if (layout->hasDim(e57plugin::e57ToPdal(i->m_name)))
         {
             i = m_extraDims->deleteDim(i);
             continue;
-		}
+        }
 
-		if (m_e57PointPrototype->isDefined(i->m_name))
+        if (m_e57PointPrototype->isDefined(i->m_name))
         {
             m_doubleBuffers[i->m_name] = std::vector<double>(m_defaultChunkSize, 0);
-            i->m_id = layout->registerOrAssignDim(i->m_name, i->m_type);	
-		}
+            i->m_id = layout->registerOrAssignDim(i->m_name, i->m_type);
+        }
         else
         {
             log()->get(LogLevel::Warning) << "Extra dimension specified in pipeline don't match in E57 prototype."
-                                             " Ignoring pipeline-specified dimension : " << i->m_name << std::endl;
+                                          " Ignoring pipeline-specified dimension : " << i->m_name << std::endl;
         }
-		++i;
+        ++i;
     }
 }
 
@@ -249,17 +249,17 @@ bool E57Reader::fillPoint(PointRef& point)
             if (dim != Dimension::Id::Classification)
             {
                 val = m_scan->rescale(dim, val);
-			}
+            }
             point.setField(dim, val);
         }
-		else
-		{
+        else
+        {
             auto dim = m_extraDims->findDim(keyValue.first);
             if (dim != m_extraDims->end())
             {
                 point.setField(dim->m_id, keyValue.second[m_currentIndex]);
-			}
-		}
+            }
+        }
     }
 
     if (m_scan->hasPose())

--- a/plugins/e57/io/E57Reader.cpp
+++ b/plugins/e57/io/E57Reader.cpp
@@ -92,8 +92,11 @@ void E57Reader::addDimensions(PointLayoutPtr layout)
         }
         else
         {
+            // Input E57 point point cloud do not have this dimension. It should be ignored.
             log()->get(LogLevel::Warning) << "Extra dimension specified in pipeline don't match in E57 prototype."
                                           " Ignoring pipeline-specified dimension : " << i->m_name << std::endl;
+            i = m_extraDims->deleteDim(i);
+            continue;
         }
         ++i;
     }

--- a/plugins/e57/io/E57Reader.hpp
+++ b/plugins/e57/io/E57Reader.hpp
@@ -38,6 +38,7 @@
 #include <pdal/Reader.hpp>
 #include <pdal/Streamable.hpp>
 #include "Scan.hpp"
+#include "Utils.hpp"
 
 namespace pdal
 {
@@ -60,6 +61,7 @@ private:
     virtual bool processOne(PointRef&) override;
     virtual void ready(PointTableRef&) override;
     virtual QuickInfo inspect() override;
+    virtual void addArgs(ProgramArgs& args) override;
 
     // Private members
     bool fillPoint(PointRef& point);
@@ -80,6 +82,8 @@ private:
     point_count_t m_defaultChunkSize;
     signed int m_currentScan;
 
+	pdal::StringList m_extraDimsSpec;
+    std::unique_ptr<e57plugin::ExtraDims> m_extraDims;
 };
 
 } // namespace pdal

--- a/plugins/e57/io/E57Reader.hpp
+++ b/plugins/e57/io/E57Reader.hpp
@@ -82,7 +82,7 @@ private:
     point_count_t m_defaultChunkSize;
     signed int m_currentScan;
 
-	pdal::StringList m_extraDimsSpec;
+    pdal::StringList m_extraDimsSpec;
     std::unique_ptr<e57plugin::ExtraDims> m_extraDims;
 };
 

--- a/plugins/e57/io/E57Writer.cpp
+++ b/plugins/e57/io/E57Writer.cpp
@@ -108,7 +108,7 @@ void E57Writer::ChunkWriter::write(pdal::PointRef& pt, std::unique_ptr<e57plugin
             auto val = pt.getFieldAs<double>(dim->m_id);
             keyValue.second[m_currentIndex] = val;
             dim->grow(val);
-		}
+        }
     }
     m_currentIndex++;
 }
@@ -164,7 +164,7 @@ void E57Writer::initialize()
 
 void E57Writer::addDimensions(PointLayoutPtr layout)
 {
-	m_extraDims = std::make_unique<e57plugin::ExtraDims>(e57plugin::parse(m_extraDimsSpec));
+    m_extraDims = std::make_unique<e57plugin::ExtraDims>(e57plugin::parse(m_extraDimsSpec));
     auto i = m_extraDims->begin();
     while (i != m_extraDims->end())
     {
@@ -175,7 +175,7 @@ void E57Writer::addDimensions(PointLayoutPtr layout)
             continue;
         }
 
-		i->m_id = layout->registerOrAssignDim(i->m_name, i->m_type);
+        i->m_id = layout->registerOrAssignDim(i->m_name, i->m_type);
         ++i;
     }
 }
@@ -187,15 +187,15 @@ void E57Writer::ready(PointTableRef table)
     m_dimensionsToWrite.clear();
     for (auto pdaldim: dimensions)
     {
-		std::string e57Dimension(pdal::e57plugin::pdalToE57(pdaldim));
-		if (!e57Dimension.empty())
-			m_dimensionsToWrite.push_back(e57Dimension);
+        std::string e57Dimension(pdal::e57plugin::pdalToE57(pdaldim));
+        if (!e57Dimension.empty())
+            m_dimensionsToWrite.push_back(e57Dimension);
     }
 
-	for (auto i = m_extraDims->begin(); i != m_extraDims->end(); ++i)
+    for (auto i = m_extraDims->begin(); i != m_extraDims->end(); ++i)
     {
         m_dimensionsToWrite.push_back(i->m_name);
-	}
+    }
 
     setupWriter();
 }
@@ -254,14 +254,14 @@ void E57Writer::done(PointTableRef table)
         // found intensity info
         e57::StructureNode intensityBox = e57::StructureNode(*m_imageFile);
         intensityBox.set("intensityMinimum",
-                     e57::IntegerNode(*m_imageFile, 0));
+                         e57::IntegerNode(*m_imageFile, 0));
         intensityBox.set(
             "intensityMaximum",
-                     e57::IntegerNode(*m_imageFile, m_chunkWriter->getIntensityLimit()));
+            e57::IntegerNode(*m_imageFile, m_chunkWriter->getIntensityLimit()));
         m_scanNode->set("intensityLimits", intensityBox);
     }
 
-	if (Utils::contains(m_dimensionsToWrite, "classification"))
+    if (Utils::contains(m_dimensionsToWrite, "classification"))
     {
         // found classification info
         e57::StructureNode classificationBox = e57::StructureNode(*m_imageFile);
@@ -273,8 +273,8 @@ void E57Writer::done(PointTableRef table)
         m_scanNode->set("classificationLimits", classificationBox);
     }
 
-	for (auto extradim = m_extraDims->begin(); extradim != m_extraDims->end();
-         ++extradim)
+    for (auto extradim = m_extraDims->begin(); extradim != m_extraDims->end();
+            ++extradim)
     {
         e57::StructureNode classificationBox = e57::StructureNode(*m_imageFile);
         classificationBox.set(extradim->m_name+"Minimum",
@@ -282,8 +282,8 @@ void E57Writer::done(PointTableRef table)
         classificationBox.set(extradim->m_name + "Maximum",
                               e57::IntegerNode(*m_imageFile, std::ceil(extradim->m_max)));
         m_scanNode->set(extradim->m_name + "Limits", classificationBox);
-		
-	}
+
+    }
 
     // Cartesian bounds
     e57::StructureNode bboxNode = e57::StructureNode(*m_imageFile);
@@ -358,8 +358,8 @@ void E57Writer::setupWriter()
     for (auto& e57Dimension: m_dimensionsToWrite)
     {
         if ((e57Dimension.find("color") != std::string::npos) ||
-            e57Dimension.find("intensity") != std::string::npos ||
-            e57Dimension.find("classification") != std::string::npos)
+                e57Dimension.find("intensity") != std::string::npos ||
+                e57Dimension.find("classification") != std::string::npos)
         {
             auto bounds = e57plugin::getPdalBounds(e57plugin::e57ToPdal(e57Dimension));
             proto.set(e57Dimension,

--- a/plugins/e57/io/E57Writer.cpp
+++ b/plugins/e57/io/E57Writer.cpp
@@ -280,12 +280,14 @@ void E57Writer::done(PointTableRef table)
     for (auto extradim = m_extraDims->begin(); extradim != m_extraDims->end();
             ++extradim)
     {
-        e57::StructureNode classificationBox = e57::StructureNode(*m_imageFile);
-        classificationBox.set(extradim->m_name+"Minimum",
-                              e57::IntegerNode(*m_imageFile, std::floor(extradim->m_min)));
-        classificationBox.set(extradim->m_name + "Maximum",
-                              e57::IntegerNode(*m_imageFile, std::ceil(extradim->m_max)));
-        m_scanNode->set(extradim->m_name + "Limits", classificationBox);
+        e57::StructureNode extraDimBox = e57::StructureNode(*m_imageFile);
+        extraDimBox.set(
+            extradim->m_name + "Minimum",
+            e57::IntegerNode(*m_imageFile, std::floor(extradim->m_min)));
+        extraDimBox.set(
+            extradim->m_name + "Maximum",
+            e57::IntegerNode(*m_imageFile, std::ceil(extradim->m_max)));
+        m_scanNode->set(extradim->m_name + "Limits", extraDimBox);
 
     }
 

--- a/plugins/e57/io/E57Writer.cpp
+++ b/plugins/e57/io/E57Writer.cpp
@@ -98,7 +98,7 @@ void E57Writer::ChunkWriter::write(pdal::PointRef& pt, std::unique_ptr<e57plugin
 
             if (pdaldim == DimId::Intensity && val > m_intensityLimit)
             {
-                m_intensityLimit = fmax(val, m_intensityLimit);
+                m_intensityLimit = m_intensityLimit << 8;
             }
             keyValue.second[m_currentIndex] = val;
         }

--- a/plugins/e57/io/E57Writer.cpp
+++ b/plugins/e57/io/E57Writer.cpp
@@ -167,7 +167,7 @@ void E57Writer::initialize()
 
 void E57Writer::addDimensions(PointLayoutPtr layout)
 {
-    m_extraDims = std::make_unique<e57plugin::ExtraDims>();
+    m_extraDims.reset(new e57plugin::ExtraDims());
     m_extraDims->parse(m_extraDimsSpec);
     auto i = m_extraDims->begin();
     auto supportedFields = e57plugin::supportedE57Types();

--- a/plugins/e57/io/E57Writer.cpp
+++ b/plugins/e57/io/E57Writer.cpp
@@ -283,10 +283,10 @@ void E57Writer::done(PointTableRef table)
         e57::StructureNode extraDimBox = e57::StructureNode(*m_imageFile);
         extraDimBox.set(
             extradim->m_name + "Minimum",
-            e57::IntegerNode(*m_imageFile, std::floor(extradim->m_min)));
+            e57::FloatNode(*m_imageFile, extradim->m_min));
         extraDimBox.set(
             extradim->m_name + "Maximum",
-            e57::IntegerNode(*m_imageFile, std::ceil(extradim->m_max)));
+            e57::FloatNode(*m_imageFile, extradim->m_max));
         m_scanNode->set(extradim->m_name + "Limits", extraDimBox);
 
     }

--- a/plugins/e57/io/E57Writer.cpp
+++ b/plugins/e57/io/E57Writer.cpp
@@ -102,12 +102,15 @@ void E57Writer::ChunkWriter::write(pdal::PointRef& pt, std::unique_ptr<e57plugin
             }
             keyValue.second[m_currentIndex] = val;
         }
-        auto dim = extraDims->findDim(keyValue.first);
-        if (dim!=extraDims->end())
+        else
         {
-            auto val = pt.getFieldAs<double>(dim->m_id);
-            keyValue.second[m_currentIndex] = val;
-            dim->grow(val);
+            auto dim = extraDims->findDim(keyValue.first);
+            if (dim!=extraDims->end())
+            {
+                auto val = pt.getFieldAs<double>(dim->m_id);
+                keyValue.second[m_currentIndex] = val;
+                dim->grow(val);
+            }
         }
     }
     m_currentIndex++;

--- a/plugins/e57/io/E57Writer.cpp
+++ b/plugins/e57/io/E57Writer.cpp
@@ -166,10 +166,11 @@ void E57Writer::addDimensions(PointLayoutPtr layout)
 {
     m_extraDims = std::make_unique<e57plugin::ExtraDims>(e57plugin::parse(m_extraDimsSpec));
     auto i = m_extraDims->begin();
+    auto supportedFields = e57plugin::supportedE57Types();
     while (i != m_extraDims->end())
     {
         auto id = Dimension::id(i->m_name);
-        if (layout->hasDim(id))
+        if (layout->hasDim(id) && Utils::contains(supportedFields, i->m_name))
         {
             i = m_extraDims->deleteDim(i);
             continue;

--- a/plugins/e57/io/E57Writer.cpp
+++ b/plugins/e57/io/E57Writer.cpp
@@ -167,7 +167,8 @@ void E57Writer::initialize()
 
 void E57Writer::addDimensions(PointLayoutPtr layout)
 {
-    m_extraDims = std::make_unique<e57plugin::ExtraDims>(e57plugin::parse(m_extraDimsSpec));
+    m_extraDims = std::make_unique<e57plugin::ExtraDims>();
+    m_extraDims->parse(m_extraDimsSpec);
     auto i = m_extraDims->begin();
     auto supportedFields = e57plugin::supportedE57Types();
     while (i != m_extraDims->end())

--- a/plugins/e57/io/E57Writer.hpp
+++ b/plugins/e57/io/E57Writer.hpp
@@ -63,6 +63,10 @@ class PDAL_DLL E57Writer : public pdal::Writer, public pdal::Streamable
 
         inline uint64_t getIntensityLimit()
         {
+            if (m_intensityLimit != 1)
+            {
+                return m_intensityLimit - 1;
+			}
             return m_intensityLimit;
         }
 

--- a/plugins/e57/io/E57Writer.hpp
+++ b/plugins/e57/io/E57Writer.hpp
@@ -1,43 +1,44 @@
 /******************************************************************************
-* Copyright (c) 2019, Helix Re Inc.
-*
-* All rights reserved.
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following
-* conditions are met:
-*
-*     * Redistributions of source code must retain the above copyright
-*       notice, this list of conditions and the following disclaimer.
-*     * Redistributions in binary form must reproduce the above copyright
-*       notice, this list of conditions and the following disclaimer in
-*       the documentation and/or other materials provided
-*       with the distribution.
-*     * Neither the name of Helix Re Inc. nor the
-*       names of its contributors may be used to endorse or promote
-*       products derived from this software without specific prior
-*       written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-* FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-* COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-* BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-* OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
-* AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
-* OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
-* OF SUCH DAMAGE.
-****************************************************************************/
+ * Copyright (c) 2019, Helix Re Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of Helix Re Inc. nor the
+ *       names of its contributors may be used to endorse or promote
+ *       products derived from this software without specific prior
+ *       written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ ****************************************************************************/
 
 #pragma once
 
-#include <pdal/pdal_types.hpp>
 #include <E57Format.h>
-#include <pdal/Writer.hpp>
 #include <pdal/Streamable.hpp>
+#include <pdal/Writer.hpp>
+#include <pdal/pdal_types.hpp>
+#include "Utils.hpp"
 
 namespace pdal
 {
@@ -47,16 +48,17 @@ class PDAL_DLL E57Writer : public pdal::Writer, public pdal::Streamable
     class PDAL_DLL ChunkWriter
     {
     public:
-        ChunkWriter(const std::vector<std::string> &dimensionsToWrite,
-                    e57::CompressedVectorNode &vectorNode);
+        ChunkWriter(const std::vector<std::string>& dimensionsToWrite,
+                    e57::CompressedVectorNode& vectorNode);
 
-        void write(pdal::PointRef &point);
+        void write(pdal::PointRef& point,
+                   std::unique_ptr<e57plugin::ExtraDims>& extraDims);
 
         void finalise();
 
         inline uint64_t getColorLimit()
         {
-            return m_colorLimit-1;
+            return m_colorLimit - 1;
         }
 
         inline uint64_t getIntensityLimit()
@@ -71,24 +73,25 @@ class PDAL_DLL E57Writer : public pdal::Writer, public pdal::Streamable
         std::vector<e57::SourceDestBuffer> m_e57buffers;
         std::unique_ptr<e57::CompressedVectorWriter> m_dataWriter;
         uint64_t m_colorLimit;
-	uint64_t m_intensityLimit;
+        uint64_t m_intensityLimit;
     };
 
 public:
     E57Writer();
     ~E57Writer();
-    E57Writer(const E57Writer &) = delete;
+    E57Writer(const E57Writer&) = delete;
     E57Writer& operator=(const E57Writer&) = delete;
 
     std::string getName() const;
 
 private:
-    virtual void addArgs(ProgramArgs &args);
+    virtual void addArgs(ProgramArgs& args);
     virtual void initialize();
-    virtual bool processOne(PointRef & point);
+    virtual bool processOne(PointRef& point);
     virtual void ready(PointTableRef table);
     virtual void write(const PointViewPtr view);
     virtual void done(PointTableRef table);
+    virtual void addDimensions(PointLayoutPtr);
 
     void setupFileHeader();
 
@@ -102,12 +105,14 @@ private:
     std::unique_ptr<e57::ImageFile> m_imageFile;
     std::unique_ptr<e57::StructureNode> m_rootNode;
     std::unique_ptr<ChunkWriter> m_chunkWriter;
-    std::unique_ptr<e57::StructureNode>  m_scanNode;
+    std::unique_ptr<e57::StructureNode> m_scanNode;
 
     // What do we write?
     std::vector<std::string> m_dimensionsToWrite;
+    pdal::StringList m_extraDimsSpec;
+    std::unique_ptr<e57plugin::ExtraDims> m_extraDims;
 
     // Bounds
     BOX3D m_bbox;
 };
-}
+} // namespace pdal

--- a/plugins/e57/io/Utils.cpp
+++ b/plugins/e57/io/Utils.cpp
@@ -256,55 +256,66 @@ point_count_t numPoints(const e57::VectorNode data3D)
     return count;
 }
 
-void dim::grow(double val) {
+void dim::grow(double val)
+{
     m_min = std::fmin(m_min, val);
     m_max = std::fmax(m_max, val);
 }
 
-void ExtraDims::addDim(std::string name, Dimension::Type type) {
+void ExtraDims::addDim(std::string name, Dimension::Type type)
+{
     dim d;
     d.m_name = name;
     d.m_type = type;
     m_dimMap.push_back(d);
 };
 
-uint16_t ExtraDims::numDims() {
+uint16_t ExtraDims::numDims()
+{
     return m_dimMap.size();
 }
 
-std::vector<dim>::iterator ExtraDims::begin() {
+std::vector<dim>::iterator ExtraDims::begin()
+{
     return m_dimMap.begin();
 }
 
-std::vector<dim>::iterator ExtraDims::end() {
+std::vector<dim>::iterator ExtraDims::end()
+{
     return m_dimMap.end();
 }
 
-std::vector<dim>::iterator ExtraDims::deleteDim(std::vector<dim>::iterator itr) {
+std::vector<dim>::iterator ExtraDims::deleteDim(std::vector<dim>::iterator itr)
+{
     return m_dimMap.erase(itr);
 }
 
-std::vector<dim>::iterator ExtraDims::findDim(std::string name) {
+std::vector<dim>::iterator ExtraDims::findDim(std::string name)
+{
     return std::find_if(begin(), end(),
-                        [name](dim d) { return d.m_name == name; });
+                        [name](dim d)
+    {
+        return d.m_name == name;
+    });
 }
 
-ExtraDims parse(pdal::StringList dimList) {
+ExtraDims parse(pdal::StringList dimList)
+{
     ExtraDims retList;
     for (auto& dim : dimList)
     {
         StringList s = Utils::split2(dim, '=');
         if (s.size() != 2)
             throw pdal_error("Invalid extra dimension specified: '" + dim +
-                        "'.  Need <dimension>=<type>..");
+                             "'.  Need <dimension>=<type>..");
         Utils::trim(s[0]);
         Utils::trim(s[1]);
         Dimension::Type type = Dimension::type(s[1]);
         if (type == Dimension::Type::None)
             throw pdal_error("Invalid extra dimension type specified: '" + dim +
-                        "'.  Need <dimension>=<type>. ");
+                             "'.  Need <dimension>=<type>. ");
         retList.addDim(s[0], type);
-	}
+    }
     return retList;
 }
 } // namespace e57plugin

--- a/plugins/e57/io/Utils.cpp
+++ b/plugins/e57/io/Utils.cpp
@@ -301,9 +301,8 @@ std::vector<Dim>::iterator ExtraDims::findDim(std::string name)
     });
 }
 
-ExtraDims parse(pdal::StringList dimList)
+void ExtraDims::parse(pdal::StringList dimList)
 {
-    ExtraDims retList;
     for (auto& dim : dimList)
     {
         StringList s = Utils::split2(dim, '=');
@@ -314,11 +313,13 @@ ExtraDims parse(pdal::StringList dimList)
         Utils::trim(s[1]);
         Dimension::Type type = Dimension::type(s[1]);
         if (type == Dimension::Type::None)
+        {
             throw pdal_error("Invalid extra dimension type specified: '" + dim +
                              "'.  Need <dimension>=<type>. ");
-        retList.addDim(s[0], type);
+        
+		}
+        addDim(s[0], type);
     }
-    return retList;
 }
 } // namespace e57plugin
 } // namespace pdal

--- a/plugins/e57/io/Utils.cpp
+++ b/plugins/e57/io/Utils.cpp
@@ -256,7 +256,7 @@ point_count_t numPoints(const e57::VectorNode data3D)
     return count;
 }
 
-void dim::grow(double val)
+void Dim::grow(double val)
 {
     m_min = std::fmin(m_min, val);
     m_max = std::fmax(m_max, val);
@@ -264,7 +264,7 @@ void dim::grow(double val)
 
 void ExtraDims::addDim(std::string name, Dimension::Type type)
 {
-    dim d;
+    Dim d;
     d.m_name = name;
     d.m_type = type;
     m_dimMap.push_back(d);
@@ -275,25 +275,25 @@ uint16_t ExtraDims::numDims()
     return m_dimMap.size();
 }
 
-std::vector<dim>::iterator ExtraDims::begin()
+std::vector<Dim>::iterator ExtraDims::begin()
 {
     return m_dimMap.begin();
 }
 
-std::vector<dim>::iterator ExtraDims::end()
+std::vector<Dim>::iterator ExtraDims::end()
 {
     return m_dimMap.end();
 }
 
-std::vector<dim>::iterator ExtraDims::deleteDim(std::vector<dim>::iterator itr)
+std::vector<Dim>::iterator ExtraDims::deleteDim(std::vector<Dim>::iterator itr)
 {
     return m_dimMap.erase(itr);
 }
 
-std::vector<dim>::iterator ExtraDims::findDim(std::string name)
+std::vector<Dim>::iterator ExtraDims::findDim(std::string name)
 {
     return std::find_if(begin(), end(),
-                        [name](dim d)
+                        [name](Dim d)
     {
         return d.m_name == name;
     });

--- a/plugins/e57/io/Utils.cpp
+++ b/plugins/e57/io/Utils.cpp
@@ -222,9 +222,11 @@ std::pair<uint64_t, uint64_t> getPdalBounds(pdal::Dimension::Id id)
         case Dim::Blue:
         case Dim::Green:
         case Dim::Intensity:
-        case Dim::Classification:
             return {std::numeric_limits<uint16_t>::min(),
                     std::numeric_limits<uint16_t>::max()};
+        case Dim::Classification:
+            return {std::numeric_limits<uint8_t>::min(),
+                    std::numeric_limits<uint8_t>::max()};
         default:
             std::string msg ="Dimension " + Dimension::name(id) +
                              " is not currently supported.";

--- a/plugins/e57/io/Utils.hpp
+++ b/plugins/e57/io/Utils.hpp
@@ -99,9 +99,10 @@ public:
     std::vector<Dim>::iterator end();
     std::vector<Dim>::iterator deleteDim(std::vector<Dim>::iterator itr);
     std::vector<Dim>::iterator findDim(std::string name);
+	void parse(pdal::StringList dimList);
 };
 
-PDAL_DLL ExtraDims parse(pdal::StringList dimList);
+
 
 } // namespace e57plugin
 } // namespace pdal

--- a/plugins/e57/io/Utils.hpp
+++ b/plugins/e57/io/Utils.hpp
@@ -35,7 +35,6 @@
 #pragma once
 
 #include <E57Format.h>
-#include <set>
 #include <pdal/DimType.hpp>
 #include <pdal/Dimension.hpp>
 #include <pdal/pdal_export.hpp>
@@ -75,7 +74,7 @@ PDAL_DLL std::pair<uint64_t, uint64_t> getPdalBounds(pdal::Dimension::Id id);
 /// Where data3D is a "/data3D" node from E57 hierarchy.
 PDAL_DLL point_count_t numPoints(const e57::VectorNode data3D);
 
-struct dim
+struct Dim
 {
     std::string m_name;
     Dimension::Id m_id;
@@ -83,23 +82,23 @@ struct dim
     double m_min;
     double m_max;
 
-    dim() : m_min(0), m_max(0) {}
+    Dim() : m_min(0), m_max(0) {}
     void grow(double val);
 };
 
 class ExtraDims
 {
 private:
-    std::vector<dim> m_dimMap;
+    std::vector<Dim> m_dimMap;
 
 public:
     ExtraDims() {};
     void addDim(std::string name, Dimension::Type type);
     uint16_t numDims();
-    std::vector<dim>::iterator begin();
-    std::vector<dim>::iterator end();
-    std::vector<dim>::iterator deleteDim(std::vector<dim>::iterator itr);
-    std::vector<dim>::iterator findDim(std::string name);
+    std::vector<Dim>::iterator begin();
+    std::vector<Dim>::iterator end();
+    std::vector<Dim>::iterator deleteDim(std::vector<Dim>::iterator itr);
+    std::vector<Dim>::iterator findDim(std::string name);
 };
 
 PDAL_DLL ExtraDims parse(pdal::StringList dimList);

--- a/plugins/e57/io/Utils.hpp
+++ b/plugins/e57/io/Utils.hpp
@@ -93,7 +93,7 @@ private:
     std::vector<dim> m_dimMap;
 
 public:
-    ExtraDims(){};
+    ExtraDims() {};
     void addDim(std::string name, Dimension::Type type);
     uint16_t numDims();
     std::vector<dim>::iterator begin();

--- a/plugins/e57/io/Utils.hpp
+++ b/plugins/e57/io/Utils.hpp
@@ -102,7 +102,5 @@ public:
 	void parse(pdal::StringList dimList);
 };
 
-
-
 } // namespace e57plugin
 } // namespace pdal

--- a/plugins/e57/io/Utils.hpp
+++ b/plugins/e57/io/Utils.hpp
@@ -1,43 +1,45 @@
 /******************************************************************************
-* Copyright (c) 2019, Helix Re Inc.
-*
-* All rights reserved.
-*
-* Redistribution and use in source and binary forms, with or without
-* modification, are permitted provided that the following
-* conditions are met:
-*
-*     * Redistributions of source code must retain the above copyright
-*       notice, this list of conditions and the following disclaimer.
-*     * Redistributions in binary form must reproduce the above copyright
-*       notice, this list of conditions and the following disclaimer in
-*       the documentation and/or other materials provided
-*       with the distribution.
-*     * Neither the name of Helix Re Inc. nor the
-*       names of its contributors may be used to endorse or promote
-*       products derived from this software without specific prior
-*       written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-* "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-* LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-* FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-* COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-* INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
-* BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
-* OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
-* AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
-* OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
-* OF SUCH DAMAGE.
-****************************************************************************/
+ * Copyright (c) 2019, Helix Re Inc.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following
+ * conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in
+ *       the documentation and/or other materials provided
+ *       with the distribution.
+ *     * Neither the name of Helix Re Inc. nor the
+ *       names of its contributors may be used to endorse or promote
+ *       products derived from this software without specific prior
+ *       written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ ****************************************************************************/
 
 #pragma once
 
-#include <string>
 #include <E57Format.h>
+#include <set>
+#include <pdal/DimType.hpp>
 #include <pdal/Dimension.hpp>
 #include <pdal/pdal_export.hpp>
+#include <string>
 
 namespace pdal
 {
@@ -46,7 +48,7 @@ namespace e57plugin
 /// converts a E57 string to the corresponding pdal dimension.
 /// returns pdal::Dimension::Id::Unknown in case the dimension is
 /// not recognised
-PDAL_DLL pdal::Dimension::Id e57ToPdal(const std::string &e57Dimension);
+PDAL_DLL pdal::Dimension::Id e57ToPdal(const std::string& e57Dimension);
 
 /// converts a pdal dimension to the corresponding E57 string .
 /// returns a empty string in case the dimension is
@@ -71,7 +73,36 @@ PDAL_DLL std::pair<uint64_t, uint64_t> getPdalBounds(pdal::Dimension::Id id);
 
 /// Returns total number of points in data3D.
 /// Where data3D is a "/data3D" node from E57 hierarchy.
-point_count_t numPoints(const e57::VectorNode data3D);
+PDAL_DLL point_count_t numPoints(const e57::VectorNode data3D);
+
+struct dim
+{
+    std::string m_name;
+    Dimension::Id m_id;
+    Dimension::Type m_type;
+    double m_min;
+    double m_max;
+
+    dim() : m_min(0), m_max(0) {}
+    void grow(double val);
+};
+
+class ExtraDims
+{
+private:
+    std::vector<dim> m_dimMap;
+
+public:
+    ExtraDims(){};
+    void addDim(std::string name, Dimension::Type type);
+    uint16_t numDims();
+    std::vector<dim>::iterator begin();
+    std::vector<dim>::iterator end();
+    std::vector<dim>::iterator deleteDim(std::vector<dim>::iterator itr);
+    std::vector<dim>::iterator findDim(std::string name);
+};
+
+PDAL_DLL ExtraDims parse(pdal::StringList dimList);
 
 } // namespace e57plugin
 } // namespace pdal

--- a/plugins/e57/test/E57ReaderTest.cpp
+++ b/plugins/e57/test/E57ReaderTest.cpp
@@ -80,7 +80,8 @@ TEST(E57Reader, testHeader)
     for (auto& e57Dim: expectedE57Dimensions)
     {
         if (e57Dim.find("nor:normal") == e57Dim.npos &&
-                e57Dim.find("cartesianInvalidState") == e57Dim.npos)
+                e57Dim.find("cartesianInvalidState") == e57Dim.npos &&
+                e57Dim.find("classification") == e57Dim.npos)
             ASSERT_TRUE(table.layout()->hasDim(pdal::e57plugin::e57ToPdal(e57Dim)));
     }
 }

--- a/plugins/e57/test/E57WriterTest.cpp
+++ b/plugins/e57/test/E57WriterTest.cpp
@@ -102,7 +102,8 @@ TEST(E57Writer, testWrite)
     auto expectedDimensions = {Dimension::Id::X,        Dimension::Id::Y,
                                Dimension::Id::Z,        Dimension::Id::Red,
                                Dimension::Id::Green,    Dimension::Id::Blue,
-                               Dimension::Id::Intensity};
+                               Dimension::Id::Intensity
+                              };
     for (point_count_t i = 0; i < cloudout->size(); i++)
     {
         auto ptB = cloudin->point(i);
@@ -118,7 +119,8 @@ TEST(E57Writer, testWrite)
     remove(outfile.c_str());
 }
 
-void writerTest_testColorRanges(pdal::Reader* r, std::string infile, int min, int max) {
+void writerTest_testColorRanges(pdal::Reader* r, std::string infile, int min, int max)
+{
     std::string outfile(Support::datapath("e57/test.e57"));
     remove(outfile.c_str());
 
@@ -144,7 +146,7 @@ void writerTest_testColorRanges(pdal::Reader* r, std::string infile, int min, in
 
     e57::VectorNode data3D(imf.root().get("/data3D"));
     auto colorLimits = (e57::StructureNode)((e57::StructureNode)data3D.get(0))
-                           .get("colorLimits");
+                       .get("colorLimits");
     std::vector<std::string> minDims{"colorRedMinimum", "colorGreenMinimum",
                                      "colorBlueMinimum"};
     std::vector<std::string> maxDims{"colorRedMaximum", "colorGreenMaximum",
@@ -199,22 +201,20 @@ TEST(E57Writer, testExtraDims)
 
     e57::VectorNode data3D(imf.root().get("/data3D"));
 
-	// Dimension which is present in input pointcloud
+    // Dimension which is present in input pointcloud
     auto limits = (e57::StructureNode)((e57::StructureNode)data3D.get(0))
-                           .get("PointSourceIdLimits");
-    ASSERT_EQ(((e57::IntegerNode)limits.get("PointSourceIdMinimum")).value(), 0);
-    ASSERT_EQ(((e57::IntegerNode)limits.get("PointSourceIdMaximum")).value(), 7326);
+                  .get("PointSourceIdLimits");
+    ASSERT_EQ(((e57::FloatNode)limits.get("PointSourceIdMinimum")).value(), 0);
+    ASSERT_EQ(((e57::FloatNode)limits.get("PointSourceIdMaximum")).value(), 7326);
 
-	// Dimension which is not present in input point cloud. All values to this dimension should be 0.
-	// i.e minimum and maximum limits should be 0.
-	limits = (e57::StructureNode)((e57::StructureNode)data3D.get(0))
-                      .get("testDimLimits");
-    ASSERT_EQ(((e57::IntegerNode)limits.get("testDimMinimum")).value(), 0);
-    ASSERT_EQ(((e57::IntegerNode)limits.get("testDimMaximum")).value(), 0);
+    // Dimension which is not present in input point cloud.
+    // This dimension should not be there in output E57.
+    ASSERT_THROW((e57::StructureNode)((e57::StructureNode)data3D.get(0))
+                 .get("testDimLimits"), E57Exception);
 
-	// Classification dimension, This will be written if available in input otherwise ignored. Not configurable through extra_dims.
-	limits = (e57::StructureNode)((e57::StructureNode)data3D.get(0))
-                      .get("classificationLimits");
+    // Classification dimension, This will be written if available in input otherwise ignored. Not configurable through extra_dims.
+    limits = (e57::StructureNode)((e57::StructureNode)data3D.get(0))
+             .get("classificationLimits");
     ASSERT_EQ(((e57::IntegerNode)limits.get("classificationMinimum")).value(), 0);
     ASSERT_EQ(((e57::IntegerNode)limits.get("classificationMaximum")).value(), 255);
 

--- a/plugins/e57/test/E57WriterTest.cpp
+++ b/plugins/e57/test/E57WriterTest.cpp
@@ -66,7 +66,7 @@ PointViewSet writertest_readE57(std::string filename, PointTableRef table)
     return reader.execute(table);
 }
 
-TEST(E57WRiter, testWrite)
+TEST(E57Writer, testWrite)
 {
     std::string outfile(Support::datapath("e57/test.e57"));
     std::string infile(Support::datapath("e57/A4.e57"));
@@ -163,7 +163,7 @@ void writerTest_testColorRanges(pdal::Reader* r, std::string infile, int min, in
     remove(outfile.c_str());
 }
 
-TEST(E57WRiter, testWriteRanges)
+TEST(E57Writer, testWriteRanges)
 {
     writerTest_testColorRanges(new LasReader(), Support::datapath("las/autzen_trim.las"), 0, 255);
     writerTest_testColorRanges(new E57Reader(), Support::datapath("e57/A4.e57"), 0, 65535);


### PR DESCRIPTION
This PR adds extra dimension support in E57 reader and writer like LAZ/LAS.
Extra dimensions can be passes as `extra_dims` argument in pipeline json as a comma separated list of dimension name=type. like follows:
```
[
    {
        "type":"readers.las",
        "filename":"E:/Helix/D/data/pointclouds/segmented-very-small.laz",
        "extra_dims":"ClusterId=double"
    },
    {
        "type":"writers.e57",
        "filename":    "d:\\autzen_trim.e57",
        "extra_dims":"ClusterId=double"
    }
]
```
If the dimension is present in input point cloud then same values will be written in output E57. Otherwise the dimension will be ignored.
Output E57 header hierarchy will look like: 

![image](https://user-images.githubusercontent.com/38933204/69055599-2b583680-0a34-11ea-9e58-b5d154f0f725.png)

