### PR TITLE
Updated to refresh buffer allocation for every scan

### DIFF
--- a/plugins/e57/io/E57Reader.hpp
+++ b/plugins/e57/io/E57Reader.hpp
@@ -67,6 +67,7 @@ private:
     bool fillPoint(PointRef& point);
     point_count_t readNextBatch();
     void setupReader();
+    void initializeBuffers();
 
     std::unique_ptr<ImageFile> m_imf;
     std::unique_ptr<VectorNode> m_data3D;

--- a/plugins/e57/io/Scan.cpp
+++ b/plugins/e57/io/Scan.cpp
@@ -233,4 +233,8 @@ double Scan::rescale(pdal::Dimension::Id dim, double value)
     return m_rescaleFactors[(int)dim] * value;
 }
 
+StructureNode Scan::getPointPrototype()
+{
+    return StructureNode(getPoints().prototype());
+}
 }

--- a/plugins/e57/io/Scan.hpp
+++ b/plugins/e57/io/Scan.hpp
@@ -56,6 +56,7 @@ public:
     void transformPoint(pdal::PointRef pt) const;
     pdal::BOX3D getBoundingBox() const;
     double rescale(pdal::Dimension::Id dim, double value);
+    StructureNode getPointPrototype();
 
 private:
     /// Called only once on constructor called


### PR DESCRIPTION
Earlier E57 reader considers that all E57 scans will have same dimensions as first scan. But that is not true in some cases. 
In this PR I have updated E57 reader to refresh buffer allocation for every scan.