### PR TITLE
increased size to save big file length

### DIFF
--- a/plugins/e57/libE57Format/src/CheckedFile.cpp
+++ b/plugins/e57/libE57Format/src/CheckedFile.cpp
@@ -156,8 +156,8 @@ void CheckedFile::read(char* buf, size_t nRead, size_t /*bufSize*/)
    //??? need to keep track of logical length?
    //??? check bufSize OK
 
-   const long long end = position(Logical) + nRead;
-   const long long logicalLength = length(Logical);
+   const off_t_ll end = position(Logical) + nRead;
+   const off_t_ll logicalLength = length(Logical);
 
    if (end > logicalLength)
    {
@@ -370,16 +370,16 @@ template<class FTYPE> CheckedFile& CheckedFile::writeFloatingPoint(FTYPE value, 
    return(*this << s);
 }
 
-void CheckedFile::seek(long long offset, OffsetMode omode)
+void CheckedFile::seek(off_t_ll offset, OffsetMode omode)
 {
    //??? check for seek beyond logicalLength_
-   const auto pos = static_cast<long long>(omode==Physical ? offset : logicalToPhysical(offset));
+   const auto pos = static_cast<off_t_ll>(omode==Physical ? offset : logicalToPhysical(offset));
    portableSeek(pos, SEEK_SET);
 }
 
-long long CheckedFile::portableSeek(long long offset, int whence)
+off_t_ll CheckedFile::portableSeek(off_t_ll offset, int whence)
 {
-   long long result;
+   off_t_ll result;
 #ifdef _WIN32
    result = _lseeki64(fd_, offset, whence);
 #elif defined(LINUX) || defined(MACOS)
@@ -399,10 +399,10 @@ long long CheckedFile::portableSeek(long long offset, int whence)
    return result;
 }
 
-long long CheckedFile::position(OffsetMode omode)
+off_t_ll CheckedFile::position(OffsetMode omode)
 {
    /// Get current file cursor position
-    const long long pos = portableSeek(0LL, SEEK_CUR);
+    const off_t_ll pos = portableSeek(0LL, SEEK_CUR);
 
    if ( omode == Physical )
    {
@@ -412,7 +412,7 @@ long long CheckedFile::position(OffsetMode omode)
    return physicalToLogical( pos );
 }
 
-long long CheckedFile::length(OffsetMode omode)
+off_t_ll CheckedFile::length(OffsetMode omode)
 {
    if ( omode == Physical )
    {
@@ -422,10 +422,10 @@ long long CheckedFile::length(OffsetMode omode)
       }
 
       // Current file position
-      long long original_pos = portableSeek(0LL, SEEK_CUR);
+      off_t_ll original_pos = portableSeek(0LL, SEEK_CUR);
 
       // End file position
-      long long end_pos = portableSeek( 0LL, SEEK_END );
+      off_t_ll end_pos = portableSeek( 0LL, SEEK_END );
 
       // Restore original position
       portableSeek( original_pos, SEEK_SET );
@@ -613,7 +613,7 @@ void CheckedFile::verifyChecksum( char *page_buffer, size_t page )
 
 void CheckedFile::getCurrentPageAndOffset(off_t_ll& page, size_t& pageOffset, OffsetMode omode)
 {
-    const long long pos = position(omode);
+    const off_t_ll pos = position(omode);
 
    if (omode == Physical)
    {

--- a/plugins/e57/libE57Format/src/CheckedFile.h
+++ b/plugins/e57/libE57Format/src/CheckedFile.h
@@ -67,8 +67,8 @@ namespace e57 {
          CheckedFile&    operator<<(uint64_t i);
          CheckedFile&    operator<<(float f);
          CheckedFile&    operator<<(double d);
-         void seek(off_t_ll offset, OffsetMode omode = Logical);
-         off_t_ll position(OffsetMode omode = Logical);
+         void			 seek(off_t_ll offset, OffsetMode omode = Logical);
+         off_t_ll		 position(OffsetMode omode = Logical);
          off_t_ll        length(OffsetMode omode = Logical);
          void            extend(off_t_ll newLength, OffsetMode omode = Logical);
          e57::ustring    fileName() const { return fileName_; }
@@ -95,7 +95,7 @@ namespace e57 {
 
          e57::ustring    fileName_;
          off_t_ll		 logicalLength_ = 0;
-         off_t_ll	  physicalLength_ = 0;
+         off_t_ll		 physicalLength_ = 0;
 
          ReadChecksumPolicy checkSumPolicy_ = CHECKSUM_POLICY_ALL;
 

--- a/plugins/e57/libE57Format/src/CheckedFile.h
+++ b/plugins/e57/libE57Format/src/CheckedFile.h
@@ -31,6 +31,8 @@
 
 #include "Common.h"
 
+typedef long long off_t_ll;
+
 namespace e57 {
 
    class CheckedFile
@@ -38,7 +40,7 @@ namespace e57 {
       public:
          static constexpr size_t   physicalPageSizeLog2 = 10;  // physical page size is 2 raised to this power
          static constexpr size_t   physicalPageSize = 1 << physicalPageSizeLog2;
-         static constexpr off_t physicalPageSizeMask = physicalPageSize - 1;
+         static constexpr off_t_ll physicalPageSizeMask = physicalPageSize - 1;
          static constexpr size_t   logicalPageSize = physicalPageSize - 4;
 
       public:
@@ -65,16 +67,16 @@ namespace e57 {
          CheckedFile&    operator<<(uint64_t i);
          CheckedFile&    operator<<(float f);
          CheckedFile&    operator<<(double d);
-         void            seek(off_t offset, OffsetMode omode = Logical);
-         off_t        position(OffsetMode omode = Logical);
-         off_t        length(OffsetMode omode = Logical);
-         void            extend(off_t newLength, OffsetMode omode = Logical);
+         void seek(off_t_ll offset, OffsetMode omode = Logical);
+         off_t_ll position(OffsetMode omode = Logical);
+         off_t_ll        length(OffsetMode omode = Logical);
+         void            extend(off_t_ll newLength, OffsetMode omode = Logical);
          e57::ustring    fileName() const { return fileName_; }
          void            close();
          void            unlink();
 
-         static inline off_t logicalToPhysical(off_t logicalOffset);
-         static inline off_t physicalToLogical(off_t physicalOffset);
+         static inline off_t_ll logicalToPhysical(off_t_ll logicalOffset);
+         static inline off_t_ll physicalToLogical(off_t_ll physicalOffset);
 
       private:
          uint32_t    checksum(char* buf, size_t size) const;
@@ -83,17 +85,17 @@ namespace e57 {
          template<class FTYPE>
          CheckedFile&    writeFloatingPoint(FTYPE value, int precision);
 
-         void        getCurrentPageAndOffset(off_t& page, size_t& pageOffset, OffsetMode omode = Logical);
-         void        readPhysicalPage(char* page_buffer, off_t page);
-         void        writePhysicalPage(char* page_buffer, off_t page);
+         void        getCurrentPageAndOffset(off_t_ll& page, size_t& pageOffset, OffsetMode omode = Logical);
+         void        readPhysicalPage(char* page_buffer, off_t_ll page);
+         void        writePhysicalPage(char* page_buffer, off_t_ll page);
          int         portableOpen( const e57::ustring &fileName,
              int flags, int mode );
-         off_t    portableSeek(off_t offset, int whence);
+         off_t_ll portableSeek(off_t_ll offset, int whence);
 
 
          e57::ustring    fileName_;
-         off_t        logicalLength_ = 0;
-         off_t        physicalLength_ = 0;
+         off_t_ll		 logicalLength_ = 0;
+         off_t_ll	  physicalLength_ = 0;
 
          ReadChecksumPolicy checkSumPolicy_ = CHECKSUM_POLICY_ALL;
 
@@ -101,17 +103,17 @@ namespace e57 {
          bool            readOnly_ = false;
    };
 
-   inline off_t CheckedFile::logicalToPhysical(off_t logicalOffset)
+   inline off_t_ll CheckedFile::logicalToPhysical(off_t_ll logicalOffset)
    {
-      const off_t page = logicalOffset / logicalPageSize;
-      const off_t remainder = logicalOffset - page*logicalPageSize;
+       const off_t_ll page = logicalOffset / logicalPageSize;
+       const off_t_ll remainder = logicalOffset - page * logicalPageSize;
 
       return page*physicalPageSize + remainder;
    }
 
-   inline off_t CheckedFile::physicalToLogical(off_t physicalOffset)
+   inline off_t_ll CheckedFile::physicalToLogical(off_t_ll physicalOffset)
    {
-      const off_t page = physicalOffset >> physicalPageSizeLog2;
+      const off_t_ll page = physicalOffset >> physicalPageSizeLog2;
       const size_t remainder = static_cast<size_t> (physicalOffset & physicalPageSizeMask);
 
       return page*logicalPageSize + (std::min)(remainder, logicalPageSize);


### PR DESCRIPTION
Earlier large files were failing to load due to the off_t (long) type was not able to hold the file size length. So changed it to long long.