### PR TITLE
Revert "increased size to save big file length"

### DIFF
--- a/plugins/e57/libE57Format/src/CheckedFile.cpp
+++ b/plugins/e57/libE57Format/src/CheckedFile.cpp
@@ -77,7 +77,7 @@ using namespace std;
 // In C++17, "static constexpr" is implicitly inline, so these are not required.
 constexpr size_t     CheckedFile::physicalPageSizeLog2;
 constexpr size_t     CheckedFile::physicalPageSize;
-constexpr off_t_ll   CheckedFile::physicalPageSizeMask;
+constexpr off_t   CheckedFile::physicalPageSizeMask;
 constexpr size_t     CheckedFile::logicalPageSize;
 
 CheckedFile::CheckedFile( const ustring &fileName, Mode mode, ReadChecksumPolicy policy ) :
@@ -156,15 +156,15 @@ void CheckedFile::read(char* buf, size_t nRead, size_t /*bufSize*/)
    //??? need to keep track of logical length?
    //??? check bufSize OK
 
-   const off_t_ll end = position(Logical) + nRead;
-   const off_t_ll logicalLength = length(Logical);
+   const off_t end = position( Logical ) + nRead;
+   const off_t logicalLength = length( Logical );
 
    if (end > logicalLength)
    {
       throw E57_EXCEPTION2(E57_ERROR_INTERNAL, "fileName=" + fileName_ + " end=" + toString(end) + " length=" + toString(logicalLength));
    }
 
-   off_t_ll page = 0;
+   off_t page = 0;
    size_t   pageOffset = 0;
 
    getCurrentPageAndOffset(page, pageOffset);
@@ -222,9 +222,9 @@ void CheckedFile::write(const char* buf, size_t nWrite)
       throw E57_EXCEPTION2(E57_ERROR_FILE_IS_READ_ONLY, "fileName=" + fileName_);
    }
 
-   off_t_ll end = position(Logical) + nWrite;
+   off_t end = position(Logical) + nWrite;
 
-   off_t_ll page = 0;
+   off_t page = 0;
    size_t   pageOffset = 0;
 
    getCurrentPageAndOffset(page, pageOffset);
@@ -237,7 +237,7 @@ void CheckedFile::write(const char* buf, size_t nWrite)
 
    while (nWrite > 0)
    {
-      const off_t_ll physicalLength = length( Physical );
+      const off_t physicalLength = length( Physical );
 
       if ( page*physicalPageSize < physicalLength )
       {
@@ -370,16 +370,16 @@ template<class FTYPE> CheckedFile& CheckedFile::writeFloatingPoint(FTYPE value, 
    return(*this << s);
 }
 
-void CheckedFile::seek(off_t_ll offset, OffsetMode omode)
+void CheckedFile::seek(off_t offset, OffsetMode omode)
 {
    //??? check for seek beyond logicalLength_
-   const auto pos = static_cast<off_t_ll>(omode==Physical ? offset : logicalToPhysical(offset));
+   const auto pos = static_cast<off_t>(omode==Physical ? offset : logicalToPhysical(offset));
    portableSeek(pos, SEEK_SET);
 }
 
-off_t_ll CheckedFile::portableSeek(off_t_ll offset, int whence)
+off_t CheckedFile::portableSeek(off_t offset, int whence)
 {
-   off_t_ll result;
+   off_t result;
 #ifdef _WIN32
    result = _lseeki64(fd_, offset, whence);
 #elif defined(LINUX) || defined(MACOS)
@@ -399,10 +399,10 @@ off_t_ll CheckedFile::portableSeek(off_t_ll offset, int whence)
    return result;
 }
 
-off_t_ll CheckedFile::position(OffsetMode omode)
+off_t CheckedFile::position(OffsetMode omode)
 {
    /// Get current file cursor position
-    const off_t_ll pos = portableSeek(0LL, SEEK_CUR);
+   const off_t pos = portableSeek(0LL, SEEK_CUR);
 
    if ( omode == Physical )
    {
@@ -412,7 +412,7 @@ off_t_ll CheckedFile::position(OffsetMode omode)
    return physicalToLogical( pos );
 }
 
-off_t_ll CheckedFile::length(OffsetMode omode)
+off_t CheckedFile::length( OffsetMode omode )
 {
    if ( omode == Physical )
    {
@@ -422,10 +422,10 @@ off_t_ll CheckedFile::length(OffsetMode omode)
       }
 
       // Current file position
-      off_t_ll original_pos = portableSeek(0LL, SEEK_CUR);
+      off_t original_pos = portableSeek( 0LL, SEEK_CUR );
 
       // End file position
-      off_t_ll end_pos = portableSeek( 0LL, SEEK_END );
+      off_t end_pos = portableSeek( 0LL, SEEK_END );
 
       // Restore original position
       portableSeek( original_pos, SEEK_SET );
@@ -436,7 +436,7 @@ off_t_ll CheckedFile::length(OffsetMode omode)
    return logicalLength_;
 }
 
-void CheckedFile::extend(off_t_ll newLength, OffsetMode omode)
+void CheckedFile::extend(off_t newLength, OffsetMode omode)
 {
 #ifdef E57_MAX_VERBOSE
    // cout << "extend newLength=" << newLength << " omode="<< omode << endl; //???
@@ -446,7 +446,7 @@ void CheckedFile::extend(off_t_ll newLength, OffsetMode omode)
       throw E57_EXCEPTION2(E57_ERROR_FILE_IS_READ_ONLY, "fileName=" + fileName_);
    }
 
-   off_t_ll newLogicalLength = 0;
+   off_t newLogicalLength = 0;
 
    if (omode==Physical)
    {
@@ -457,7 +457,7 @@ void CheckedFile::extend(off_t_ll newLength, OffsetMode omode)
       newLogicalLength = newLength;
    }
 
-   off_t_ll currentLogicalLength = length(Logical);
+   off_t currentLogicalLength = length(Logical);
 
    /// Make sure we are trying to make file longer
    if (newLogicalLength < currentLogicalLength) {
@@ -468,12 +468,12 @@ void CheckedFile::extend(off_t_ll newLength, OffsetMode omode)
    }
 
    /// Calc how may zero bytes we have to add to end
-   off_t_ll nWrite = newLogicalLength - currentLogicalLength;
+   off_t nWrite = newLogicalLength - currentLogicalLength;
 
    /// Seek to current end of file
    seek(currentLogicalLength, Logical);
 
-   off_t_ll page = 0;
+   off_t page = 0;
    size_t   pageOffset = 0;
 
    getCurrentPageAndOffset(page, pageOffset);
@@ -497,7 +497,7 @@ void CheckedFile::extend(off_t_ll newLength, OffsetMode omode)
 
    while (nWrite > 0)
    {
-      const off_t_ll physicalLength = length( Physical );
+      const off_t physicalLength = length( Physical );
 
       if ( page*physicalPageSize < physicalLength )
       {
@@ -600,7 +600,7 @@ void CheckedFile::verifyChecksum( char *page_buffer, size_t page )
 
    if ( check_sum_in_page != check_sum )
    {
-      const off_t_ll physicalLength = length( Physical );
+      const off_t physicalLength = length( Physical );
 
       throw E57_EXCEPTION2(E57_ERROR_BAD_CHECKSUM,
                            "fileName=" + fileName_
@@ -611,9 +611,9 @@ void CheckedFile::verifyChecksum( char *page_buffer, size_t page )
    }
 }
 
-void CheckedFile::getCurrentPageAndOffset(off_t_ll& page, size_t& pageOffset, OffsetMode omode)
+void CheckedFile::getCurrentPageAndOffset(off_t& page, size_t& pageOffset, OffsetMode omode)
 {
-    const off_t_ll pos = position(omode);
+   const off_t pos = position( omode );
 
    if (omode == Physical)
    {
@@ -627,14 +627,14 @@ void CheckedFile::getCurrentPageAndOffset(off_t_ll& page, size_t& pageOffset, Of
    }
 }
 
-void CheckedFile::readPhysicalPage(char* page_buffer, off_t_ll page)
+void CheckedFile::readPhysicalPage(char* page_buffer, off_t page)
 {
 #ifdef E57_MAX_VERBOSE
    // cout << "readPhysicalPage, page:" << page << endl;
 #endif
 
 #ifdef E57_CHECK_FILE_DEBUG
-   const off_t_ll physicalLength = length( Physical );
+   const off_t physicalLength = length( Physical );
 
    assert( page*physicalPageSize < physicalLength );
 #endif
@@ -656,7 +656,7 @@ void CheckedFile::readPhysicalPage(char* page_buffer, off_t_ll page)
    }
 }
 
-void CheckedFile::writePhysicalPage(char* page_buffer, off_t_ll page)
+void CheckedFile::writePhysicalPage(char* page_buffer, off_t page)
 {
 #ifdef E57_MAX_VERBOSE
    // cout << "writePhysicalPage, page:" << page << endl;

--- a/plugins/e57/libE57Format/src/CheckedFile.h
+++ b/plugins/e57/libE57Format/src/CheckedFile.h
@@ -31,8 +31,6 @@
 
 #include "Common.h"
 
-typedef long long off_t_ll;
-
 namespace e57 {
 
    class CheckedFile
@@ -40,7 +38,7 @@ namespace e57 {
       public:
          static constexpr size_t   physicalPageSizeLog2 = 10;  // physical page size is 2 raised to this power
          static constexpr size_t   physicalPageSize = 1 << physicalPageSizeLog2;
-         static constexpr off_t_ll physicalPageSizeMask = physicalPageSize - 1;
+         static constexpr off_t physicalPageSizeMask = physicalPageSize - 1;
          static constexpr size_t   logicalPageSize = physicalPageSize - 4;
 
       public:
@@ -67,16 +65,16 @@ namespace e57 {
          CheckedFile&    operator<<(uint64_t i);
          CheckedFile&    operator<<(float f);
          CheckedFile&    operator<<(double d);
-         void			 seek(off_t_ll offset, OffsetMode omode = Logical);
-         off_t_ll		 position(OffsetMode omode = Logical);
-         off_t_ll        length(OffsetMode omode = Logical);
-         void            extend(off_t_ll newLength, OffsetMode omode = Logical);
+         void            seek(off_t offset, OffsetMode omode = Logical);
+         off_t        position(OffsetMode omode = Logical);
+         off_t        length(OffsetMode omode = Logical);
+         void            extend(off_t newLength, OffsetMode omode = Logical);
          e57::ustring    fileName() const { return fileName_; }
          void            close();
          void            unlink();
 
-         static inline off_t_ll logicalToPhysical(off_t_ll logicalOffset);
-         static inline off_t_ll physicalToLogical(off_t_ll physicalOffset);
+         static inline off_t logicalToPhysical(off_t logicalOffset);
+         static inline off_t physicalToLogical(off_t physicalOffset);
 
       private:
          uint32_t    checksum(char* buf, size_t size) const;
@@ -85,17 +83,17 @@ namespace e57 {
          template<class FTYPE>
          CheckedFile&    writeFloatingPoint(FTYPE value, int precision);
 
-         void        getCurrentPageAndOffset(off_t_ll& page, size_t& pageOffset, OffsetMode omode = Logical);
-         void        readPhysicalPage(char* page_buffer, off_t_ll page);
-         void        writePhysicalPage(char* page_buffer, off_t_ll page);
+         void        getCurrentPageAndOffset(off_t& page, size_t& pageOffset, OffsetMode omode = Logical);
+         void        readPhysicalPage(char* page_buffer, off_t page);
+         void        writePhysicalPage(char* page_buffer, off_t page);
          int         portableOpen( const e57::ustring &fileName,
              int flags, int mode );
-         off_t_ll portableSeek(off_t_ll offset, int whence);
+         off_t    portableSeek(off_t offset, int whence);
 
 
          e57::ustring    fileName_;
-         off_t_ll		 logicalLength_ = 0;
-         off_t_ll		 physicalLength_ = 0;
+         off_t        logicalLength_ = 0;
+         off_t        physicalLength_ = 0;
 
          ReadChecksumPolicy checkSumPolicy_ = CHECKSUM_POLICY_ALL;
 
@@ -103,17 +101,17 @@ namespace e57 {
          bool            readOnly_ = false;
    };
 
-   inline off_t_ll CheckedFile::logicalToPhysical(off_t_ll logicalOffset)
+   inline off_t CheckedFile::logicalToPhysical(off_t logicalOffset)
    {
-       const off_t_ll page = logicalOffset / logicalPageSize;
-       const off_t_ll remainder = logicalOffset - page * logicalPageSize;
+      const off_t page = logicalOffset / logicalPageSize;
+      const off_t remainder = logicalOffset - page*logicalPageSize;
 
       return page*physicalPageSize + remainder;
    }
 
-   inline off_t_ll CheckedFile::physicalToLogical(off_t_ll physicalOffset)
+   inline off_t CheckedFile::physicalToLogical(off_t physicalOffset)
    {
-      const off_t_ll page = physicalOffset >> physicalPageSizeLog2;
+      const off_t page = physicalOffset >> physicalPageSizeLog2;
       const size_t remainder = static_cast<size_t> (physicalOffset & physicalPageSizeMask);
 
       return page*logicalPageSize + (std::min)(remainder, logicalPageSize);


### PR DESCRIPTION
Reverts helix-re/PDAL#36

As mentioned in the PR, I have concerns regarding the compatibility of that change with third party e57 readers.